### PR TITLE
add --merged flag to latestLocalGitTagVersion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,7 @@
 
 ## unreleased
 
-- removed jgit dependency, used com.lovelysystems.gradle.LSGit instead
-- add --merged flag to latestLocalGitTagVersion 
+- allow patch updates in createTag for older releases
 
 ## 2018-08-11 / 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - removed jgit dependency, used com.lovelysystems.gradle.LSGit instead
+- add --merged flag to latestLocalGitTagVersion 
 
 ## 2018-08-11 / 1.0.0
 

--- a/src/main/kotlin/com/lovelysystems/gradle/LSGit.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/LSGit.kt
@@ -96,7 +96,7 @@ class LSGit(val dir: File) {
         }
     }
 
-    fun latestLocalGitTagVersion(releaseVersion: Version? = null): Version? {
+    fun latestLocalGitTagPatchOfVersion(releaseVersion: Version? = null): Version? {
         var versions = gitCmd("tag", "-l", "--sort=-v:refname").lines().filter { isProductionVersion(it) }.map(Version.Companion::fromIdent)
         versions =
                 if (releaseVersion != null)
@@ -125,9 +125,9 @@ class LSGit(val dir: File) {
             throw RuntimeException("Current head is already tagged with production tag $currentVersion")
         }
 
-        val latestVersionLocal = latestLocalGitTagVersion(releaseInfo.second)
-        if (latestVersionLocal != null && latestVersionLocal >= releaseInfo.second) {
-            throw RuntimeException("Version number superseded: $latestVersionLocal >= ${releaseInfo.second}")
+        val latestPatchOfVersionLocal = latestLocalGitTagPatchOfVersion(releaseInfo.second)
+        if (latestPatchOfVersionLocal != null && latestPatchOfVersionLocal >= releaseInfo.second) {
+            throw RuntimeException("Version number superseded: $latestPatchOfVersionLocal >= ${releaseInfo.second}")
         }
 
         gitCmd(

--- a/src/main/kotlin/com/lovelysystems/gradle/LSGit.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/LSGit.kt
@@ -97,8 +97,13 @@ class LSGit(val dir: File) {
     }
 
     fun latestLocalGitTagVersion(): Version? {
-        return gitCmd("tag", "-l", "--sort=-v:refname").lines().find { isProductionVersion(it) }?.let {
-            Version.fromIdent(it)
+        // --merged flag fails if there are no commits
+        try {
+            return gitCmd("tag", "-l", "--sort=-v:refname", "--merged").lines().find { isProductionVersion(it) }?.let {
+                Version.fromIdent(it)
+            }
+        } catch (e: Exception) {
+            return null
         }
     }
 

--- a/src/test/kotlin/com/lovelysystems/gradle/LSGitTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/LSGitTest.kt
@@ -183,10 +183,14 @@ class LSGitTest {
 
         g.gitCmd("tag", "0.0.1")
         g.latestLocalGitTagVersion() shouldEqual Version(0, 0, 1)
+
         g.gitCmd("checkout", "-b", "release")
+
+        g.gitCmd("checkout", "master")
         g.createVersionedFile("release.txt", tag = "0.1.0")
         g.latestLocalGitTagVersion() shouldEqual Version(0, 1, 0)
-        g.gitCmd("checkout", "master")
-        g.latestLocalGitTagVersion() shouldEqual Version(0, 0, 1)
+
+        g.gitCmd("checkout", "release")
+        g.latestLocalGitTagVersion(Version(0, 0, 0)) shouldEqual Version(0, 0, 1)
     }
 }

--- a/src/test/kotlin/com/lovelysystems/gradle/LSGitTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/LSGitTest.kt
@@ -148,6 +148,12 @@ class LSGitTest {
         downstream.gitCmd("push", "--set-upstream", "origin", "release/0.0.0")
         downstream.createVersionTag().second.toString() shouldBeEqualTo "0.0.3"
         downstream.validateProductionTag(downstream.describe())
+
+        downstream.createVersionedFile("c.txt")
+        downstream.gitCmd("push", "--set-upstream", "origin", "release/0.0.0")
+
+        func = { downstream.createVersionTag() }
+        func shouldThrow RuntimeException::class withMessage "Version number superseded: 0.0.3 >= 0.0.3"
     }
 
     @Test
@@ -171,26 +177,26 @@ class LSGitTest {
     }
 
     @Test
-    fun testLatestLocalGitTagVersion() {
+    fun testLatestLocalGitTagPatchOfVersion() {
         val g = LSGit(tmp.root)
         g.gitCmd("init")
-        g.latestLocalGitTagVersion() shouldBe null
+        g.latestLocalGitTagPatchOfVersion() shouldBe null
         tmp.root.resolve("some.txt").writeText("content")
         g.gitCmd("add", ".")
         g.gitCmd("commit", "-m", "some commit")
         g.gitCmd("tag", "not_a_valid_release_tag")
-        g.latestLocalGitTagVersion() shouldBe null
+        g.latestLocalGitTagPatchOfVersion() shouldBe null
 
         g.gitCmd("tag", "0.0.1")
-        g.latestLocalGitTagVersion() shouldEqual Version(0, 0, 1)
+        g.latestLocalGitTagPatchOfVersion() shouldEqual Version(0, 0, 1)
 
         g.gitCmd("checkout", "-b", "release")
 
         g.gitCmd("checkout", "master")
         g.createVersionedFile("release.txt", tag = "0.1.0")
-        g.latestLocalGitTagVersion() shouldEqual Version(0, 1, 0)
+        g.latestLocalGitTagPatchOfVersion() shouldEqual Version(0, 1, 0)
 
         g.gitCmd("checkout", "release")
-        g.latestLocalGitTagVersion(Version(0, 0, 0)) shouldEqual Version(0, 0, 1)
+        g.latestLocalGitTagPatchOfVersion(Version(0, 0, 0)) shouldEqual Version(0, 0, 1)
     }
 }

--- a/src/test/kotlin/com/lovelysystems/gradle/LSGitTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/LSGitTest.kt
@@ -121,6 +121,33 @@ class LSGitTest {
 
         func = { downstream.createVersionTag() }
         func shouldThrow RuntimeException::class withMessage "Version number superseded: 0.0.2 >= 0.0.2"
+
+        downstream.gitCmd("checkout", "-b", "release/0.0.0")
+        downstream.gitCmd("checkout", "master")
+
+        downstream.createVersionedFile("newRealease.txt", tag = "0.1.0")
+
+        downstream.gitCmd("checkout", "release/0.0.0")
+        downstream.createVersionedFile("CHANGES.md", content =
+        """
+# Changes for some cool project
+
+## 2018-01-16 / 0.0.3
+
+- the hotfix in 0.0.3
+
+## 2018-01-15 / 0.0.2
+
+- the change in 0.0.2
+
+## 2017-01-15 0.0.1
+
+- initial version
+"""
+        )
+        downstream.gitCmd("push", "--set-upstream", "origin", "release/0.0.0")
+        downstream.createVersionTag().second.toString() shouldBeEqualTo "0.0.3"
+        downstream.validateProductionTag(downstream.describe())
     }
 
     @Test
@@ -155,6 +182,11 @@ class LSGitTest {
         g.latestLocalGitTagVersion() shouldBe null
 
         g.gitCmd("tag", "0.0.1")
+        g.latestLocalGitTagVersion() shouldEqual Version(0, 0, 1)
+        g.gitCmd("checkout", "-b", "release")
+        g.createVersionedFile("release.txt", tag = "0.1.0")
+        g.latestLocalGitTagVersion() shouldEqual Version(0, 1, 0)
+        g.gitCmd("checkout", "master")
         g.latestLocalGitTagVersion() shouldEqual Version(0, 0, 1)
     }
 }


### PR DESCRIPTION
to be able to allow hotfix tags only look at the tags of the current
branch

--merged man page entry
```
--merged [<commit>]
   Only list tags whose commits are reachable from the specified commit (HEAD if not specified), incompatible with --no-merged.
```
