### PR TITLE
Allow to push DevDockerImage after it's already been pushed as release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - allow patch updates in createTag for older releases
 - upgrade gradle to 4.10, older version won't work any more
+- allow to push dev image even if the same build was pushed as release first
 
 ## 2018-08-11 / 1.0.0
 

--- a/src/main/kotlin/com/lovelysystems/gradle/LSDocker.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/LSDocker.kt
@@ -80,7 +80,8 @@ fun Project.dockerProject(repository: String, files: CopySpec) {
                         errorOutput = eo
 
                     }
-                    if (e.exitValue == 0) {
+                    val shouldPushDev = project.gradle.taskGraph.hasTask(":pushDockerDevImage")
+                    if (e.exitValue == 0 && !shouldPushDev) {
                         throw RuntimeException("tag already exists $tag")
                     }
                 }


### PR DESCRIPTION
Fail pushDockerImage only if it's already pushed and no DevImage should be pushed