### PR TITLE
pythonProject: do not delete sdist build when not executed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes for Lovely Gradle Plugin
 
+## 2021-12-16 / 1.6.2
+
+- fix: pythonProject: do not delete sdist build when not executed
+
 ## 2021-10-12 / 1.6.1
 
 - fix: re-enabled docker push, which was disabled for testing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.lovelysystems"
-version = "1.6.1"
+version = "1.6.2"
 
 val pluginId = "com.lovelysystems.gradle"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -160,8 +160,8 @@ fun Project.pythonProject(pythonExecutable: String) {
         inputs.files(fileTree("src"), pythonSettings.setupFile, "MANIFEST.in")
         val out = buildDir.resolve("sdist")
         outputs.dir(out)
-        out.deleteRecursively()
         doLast {
+            out.deleteRecursively()
             exec {
                 commandLine(pythonSettings.python, pythonSettings.setupFile, "sdist", "--dist-dir", out)
             }


### PR DESCRIPTION
@dobe Do we release this like this?
https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html

Do I need an account/invitation for that?