### PR TITLE
do not verify on push of createTag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes for Lovely Gradle Plugin
 
+## 2022-05-25 / 1.7.0
+
+- do not verify on push of createTag
+
 ## 2021-12-16 / 1.6.2
 
 - fix: pythonProject: do not delete sdist build when not executed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.lovelysystems"
-version = "1.6.2"
+version = "1.7.0"
 
 val pluginId = "com.lovelysystems.gradle"
 

--- a/src/main/kotlin/com/lovelysystems/gradle/LSGit.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/LSGit.kt
@@ -134,7 +134,7 @@ class LSGit(val dir: File) {
             "tag", "-a", "-m", "Release ${releaseInfo.second} from ${releaseInfo.first}",
             releaseInfo.second.toString()
         )
-        gitCmd("push", "--tags", "-q")
+        gitCmd("push", "--tags", "--no-verify", "-q")
         return releaseInfo
     }
 }


### PR DESCRIPTION
background: some projects use hooks and validation takes too long for the job to finish. when making a tag we should be in a stage where everything is already verified, so skip that verification.

e.g. az.cmsui
```
* What went wrong:
Execution failed for task ':createTag'.
> process hasn't exited
```