### PR TITLE
Prefer the custom docker-container builder over the default builder for local builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes for Lovely Gradle Plugin
 
+## Unreleased
+
+- fix: Prefer the usage of the custom docker-container builder for local builds
+  in order to utilize BuildKit features.
+
 ## 2022-08-24 / 1.8.0
 
 - Upgrade to gradle 7.5.1

--- a/src/main/kotlin/com/lovelysystems/gradle/LSDocker.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/LSDocker.kt
@@ -38,17 +38,17 @@ fun Project.dockerProject(repository: String, files: CopySpec, stages: List<Stri
             val buildArgs = if (push) {
                 arrayOf(
                     "--platform", platforms.joinToString(","),
-                    "--builder", multiplatformBuilder,
                     "--push"
                 )
             } else {
                 // local builds do not require a foreign target platform
-                // uses the default builder
                 arrayOf("--load")  // ensures build image is registered in local docker registry
             }
             return arrayOf(
                 "docker", "buildx",
                 "build", ".",
+                // always use the builder using the docker-container driver in order to access BuildKit features
+                "--builder", multiplatformBuilder,
                 *imageTags,
                 *buildArgs,
             )


### PR DESCRIPTION
In order to get the enhanced features of BuildKit let's use the custom docker-container builder for local builds (no push) as well.