### PR TITLE
Fix python builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 # Changes for Lovely Gradle Plugin
 
+## Unreleased
+
+- pythonProject: use latest pip-tools and remove pins for setuptools and pip 
+
 ## 2023-01-30 / 1.11.0
 
-- nail setuptools < 66.0.0 for Python projects see ttps://github.com/pypa/setuptools/issues/3772
+- nail setuptools < 66.0.0 for Python projects see https://github.com/pypa/setuptools/issues/3772
 - updated Gradle (7.5.1 -> 7.6), Kotlin (1.4.31 -> 1.7.10) and other dependencies in the project
 
 ## 2022-12-06 / 1.10.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - pythonProject: use latest pip-tools and remove pins for setuptools and pip 
+- setuptools compatibility: convert git describe output to pep440 compatible version
 
 ## 2023-01-30 / 1.11.0
 

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -150,7 +150,7 @@ open class PyTestTask : DefaultTask() {
  */
 fun pep440Version(versionString: String): String {
     val defaultVersion = "0.0"
-    val r = Regex("^(?<public>\\d+(?>\\.\\d+)+(?>.(?>a|b|rc|dev|post)\\d*)?(?=-|\$))?-?(?<local>[\\w-]*(?>.dirty)?)\$")
+    val r = Regex("^(?<public>\\d+(?>\\.\\d+)+(?=-|\$))?-?(?<local>[\\w-]*(?>.dirty)?)\$")
     val match = r.matchEntire(versionString)
 
     return if (match != null) {

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -150,7 +150,7 @@ open class PyTestTask : DefaultTask() {
  */
 fun pep440Version(versionString: String): String {
     val defaultVersion = "0.0"
-    val r = Regex("^(?<public>\\d(?>\\.\\d)*(?>.(?>a|b|rc|dev|post)\\d*)?(?=-|\$))?-?(?<local>[\\w-]*(?>.dirty)?)\$")
+    val r = Regex("^(?<public>\\d+(?>\\.\\d+)+(?>.(?>a|b|rc|dev|post)\\d*)?(?=-|\$))?-?(?<local>[\\w-]*(?>.dirty)?)\$")
     val match = r.matchEntire(versionString)
 
     return if (match != null) {

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -150,7 +150,7 @@ open class PyTestTask : DefaultTask() {
  */
 fun pep440Version(versionString: String): String {
     val defaultVersion = "0.0"
-    val r = Regex("^(?<public>\\d(?>\\.\\d)*(?>.(?>a|b|rc|dev|post)\\d*)?)?-?(?<local>[\\w-]*(?>.dirty)?)\$")
+    val r = Regex("^(?<public>\\d(?>\\.\\d)*(?>.(?>a|b|rc|dev|post)\\d*)?(?=-|\$))?-?(?<local>[\\w-]*(?>.dirty)?)\$")
     val match = r.matchEntire(versionString)
 
     return if (match != null) {

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -137,6 +137,8 @@ open class PyTestTask : DefaultTask() {
     }
 }
 
+val versionRegex = Regex("^(?<public>\\d+(?>\\.\\d+)+(?=-|\$))?-?(?<local>[\\w-]*(?>.dirty)?)\$")
+
 /**
  * turn the version string provided by task `printVersion`
  * into a [PEP440](https://peps.python.org/pep-0440) compatible version
@@ -150,15 +152,15 @@ open class PyTestTask : DefaultTask() {
  */
 fun pep440Version(versionString: String): String {
     val defaultVersion = "0.0"
-    val r = Regex("^(?<public>\\d+(?>\\.\\d+)+(?=-|\$))?-?(?<local>[\\w-]*(?>.dirty)?)\$")
-    val match = r.matchEntire(versionString)
+    val match = versionRegex.matchEntire(versionString)
 
     return if (match != null) {
         val groups = match.groups as MatchNamedGroupCollection
         val public = groups["public"]?.value ?: defaultVersion
         val local = groups["local"]?.value
         if (local != "") {
-            "$public+$local"
+            // pep440 local version only supports alphanumeric values and dots
+            """$public+${local?.replace("-", ".")}"""
         } else {
             public
         }

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -47,9 +47,9 @@ open class VenvTask : DefaultTask() {
         project.exec {
             commandLine(
                 project.pythonSettings.pip, "install", "--upgrade",
-                "pip<=21.2.4",  // nailed because of pip-tools bug see https://github.com/jazzband/pip-tools/issues/1503
-                "setuptools<66.0.0",  // nailed because of https://github.com/pypa/setuptools/issues/3772
-                "pip-tools==6.2.0"
+                "pip",
+                "setuptools",
+                "pip-tools==6.12.1"
             )
         }
     }

--- a/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
@@ -8,17 +8,17 @@ class PythonProjectTest {
     @Test
     fun testPep440Version() {
         // no release yet
-        pep440Version("gcbcdbe6") shouldBeEqualTo "0.0+gcbcdbe6"
+        pep440Version("757ea77") shouldBeEqualTo "0.0+757ea77"
         // dirty commit w/o release
-        pep440Version("gcbcdbe6.dirty") shouldBeEqualTo "0.0+gcbcdbe6.dirty"
+        pep440Version("757ea77.dirty") shouldBeEqualTo "0.0+757ea77.dirty"
         // proper release
         pep440Version("1.2") shouldBeEqualTo "1.2"
         // release with additional commits
-        pep440Version("1.2-2-gcbcdbe6") shouldBeEqualTo "1.2+2-gcbcdbe6"
+        pep440Version("1.2-2-757ea77") shouldBeEqualTo "1.2+2-757ea77"
         // release with additional commits and dirty state
-        pep440Version("1.2-2-gcbcdbe6.dirty") shouldBeEqualTo "1.2+2-gcbcdbe6.dirty"
+        pep440Version("1.2-2-757ea77.dirty") shouldBeEqualTo "1.2+2-757ea77.dirty"
         // unlimited release segments
-        pep440Version("1.2.3.4.5-4-gcbcdbe6.dirty") shouldBeEqualTo "1.2.3.4.5+4-gcbcdbe6.dirty"
+        pep440Version("1.2.3.4.5-4-757ea77.dirty") shouldBeEqualTo "1.2.3.4.5+4-757ea77.dirty"
         // proper pep440 version not converted
         pep440Version("1.2.3.dev0") shouldBeEqualTo "1.2.3.dev0"
         pep440Version("1.2.3.a1") shouldBeEqualTo "1.2.3.a1"

--- a/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
@@ -14,12 +14,12 @@ class PythonProjectTest {
         // proper release
         pep440Version("1.2") shouldBeEqualTo "1.2"
         // release with additional commits
-        pep440Version("1.2-2-757ea77") shouldBeEqualTo "1.2+2-757ea77"
+        pep440Version("1.2-2-757ea77") shouldBeEqualTo "1.2+2.757ea77"
         // release with additional commits and dirty state
-        pep440Version("1.2-2-757ea77.dirty") shouldBeEqualTo "1.2+2-757ea77.dirty"
+        pep440Version("1.2-2-757ea77.dirty") shouldBeEqualTo "1.2+2.757ea77.dirty"
         // unlimited release segments
-        pep440Version("1.234.5.6-4-757ea77.dirty") shouldBeEqualTo "1.234.5.6+4-757ea77.dirty"
-        pep440Version("123.4.55.6-4-757ea77.dirty") shouldBeEqualTo "123.4.55.6+4-757ea77.dirty"
+        pep440Version("1.234.5.6-4-757ea77.dirty") shouldBeEqualTo "1.234.5.6+4.757ea77.dirty"
+        pep440Version("123.4.55.6-4-757ea77.dirty") shouldBeEqualTo "123.4.55.6+4.757ea77.dirty"
 
         // if version can't be parsed - simply return it
         pep440Version("a0.63.1-8-g9e7b2ab.dirty") shouldBeEqualTo "a0.63.1-8-g9e7b2ab.dirty"

--- a/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
@@ -18,7 +18,8 @@ class PythonProjectTest {
         // release with additional commits and dirty state
         pep440Version("1.2-2-757ea77.dirty") shouldBeEqualTo "1.2+2-757ea77.dirty"
         // unlimited release segments
-        pep440Version("1.2.3.4.5-4-757ea77.dirty") shouldBeEqualTo "1.2.3.4.5+4-757ea77.dirty"
+        pep440Version("1.234.5.6-4-757ea77.dirty") shouldBeEqualTo "1.234.5.6+4-757ea77.dirty"
+        pep440Version("123.4.55.6-4-757ea77.dirty") shouldBeEqualTo "123.4.55.6+4-757ea77.dirty"
         // proper pep440 version not converted
         pep440Version("1.2.3.dev0") shouldBeEqualTo "1.2.3.dev0"
         pep440Version("1.2.3.a1") shouldBeEqualTo "1.2.3.a1"
@@ -27,7 +28,7 @@ class PythonProjectTest {
         pep440Version("1.2.3.post5") shouldBeEqualTo "1.2.3.post5"
 
         // if version can't be parsed - simply return it
-        pep440Version("unsupported.version") shouldBeEqualTo "unsupported.version"
+        pep440Version("a0.63.1-8-g9e7b2ab.dirty") shouldBeEqualTo "a0.63.1-8-g9e7b2ab.dirty"
     }
 
 }

--- a/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
@@ -1,0 +1,33 @@
+package com.lovelysystems.gradle
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class PythonProjectTest {
+
+    @Test
+    fun testPep440Version() {
+        // no release yet
+        pep440Version("gcbcdbe6") shouldBeEqualTo "0.0+gcbcdbe6"
+        // dirty commit w/o release
+        pep440Version("gcbcdbe6.dirty") shouldBeEqualTo "0.0+gcbcdbe6.dirty"
+        // proper release
+        pep440Version("1.2") shouldBeEqualTo "1.2"
+        // release with additional commits
+        pep440Version("1.2-2-gcbcdbe6") shouldBeEqualTo "1.2+2-gcbcdbe6"
+        // release with additional commits and dirty state
+        pep440Version("1.2-2-gcbcdbe6.dirty") shouldBeEqualTo "1.2+2-gcbcdbe6.dirty"
+        // unlimited release segments
+        pep440Version("1.2.3.4.5-4-gcbcdbe6.dirty") shouldBeEqualTo "1.2.3.4.5+4-gcbcdbe6.dirty"
+        // proper pep440 version not converted
+        pep440Version("1.2.3.dev0") shouldBeEqualTo "1.2.3.dev0"
+        pep440Version("1.2.3.a1") shouldBeEqualTo "1.2.3.a1"
+        pep440Version("1.2.3.b20") shouldBeEqualTo "1.2.3.b20"
+        pep440Version("1.2.3.rc40") shouldBeEqualTo "1.2.3.rc40"
+        pep440Version("1.2.3.post5") shouldBeEqualTo "1.2.3.post5"
+
+        // if version can't be parsed - simply return it
+        pep440Version("unsupported.version") shouldBeEqualTo "unsupported.version"
+    }
+
+}

--- a/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
+++ b/src/test/kotlin/com/lovelysystems/gradle/PythonProjectTest.kt
@@ -20,15 +20,11 @@ class PythonProjectTest {
         // unlimited release segments
         pep440Version("1.234.5.6-4-757ea77.dirty") shouldBeEqualTo "1.234.5.6+4-757ea77.dirty"
         pep440Version("123.4.55.6-4-757ea77.dirty") shouldBeEqualTo "123.4.55.6+4-757ea77.dirty"
-        // proper pep440 version not converted
-        pep440Version("1.2.3.dev0") shouldBeEqualTo "1.2.3.dev0"
-        pep440Version("1.2.3.a1") shouldBeEqualTo "1.2.3.a1"
-        pep440Version("1.2.3.b20") shouldBeEqualTo "1.2.3.b20"
-        pep440Version("1.2.3.rc40") shouldBeEqualTo "1.2.3.rc40"
-        pep440Version("1.2.3.post5") shouldBeEqualTo "1.2.3.post5"
 
         // if version can't be parsed - simply return it
         pep440Version("a0.63.1-8-g9e7b2ab.dirty") shouldBeEqualTo "a0.63.1-8-g9e7b2ab.dirty"
+        // also proper version numbers (though not created by this plugin) are not converted
+        pep440Version("1.2.3.rc40") shouldBeEqualTo "1.2.3.rc40"
     }
 
 }


### PR DESCRIPTION
use latest pip-tools, remove version pins for setuptools and pip.

create version numbers that are pep440 compatible (setuptools started to enforce this from version 66 on [see issue](https://github.com/pypa/setuptools/issues/3772))