### PR TITLE
use pip-tools version 6.13.0 to work with pip >= 23.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes for Lovely Gradle Plugin
 
+## 2023-02-01 / 1.11.4
+
+### Fixes
+
+- use pip-tools version 6.13.0 to work with pip >= 23.1
+  (https://pyup.io/packages/pypi/pip-tools/changelog?page=1&#6.13.0)
+
 ## 2023-02-01 / 1.11.3
 
 ### Fixes
@@ -14,7 +21,7 @@
 
 ### Fixes
 
-- pythonProject: use latest pip-tools and remove pins for setuptools and pip 
+- pythonProject: use latest pip-tools and remove pins for setuptools and pip
 - setuptools compatibility: convert git describe output to pep440 compatible version
 
 ## 2023-01-30 / 1.11.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 group = "com.lovelysystems"
-version = "1.11.3"
+version = "1.11.4"
 
 val pluginId = "com.lovelysystems.gradle"
 

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -49,7 +49,7 @@ open class VenvTask : DefaultTask() {
                 project.pythonSettings.pip, "install", "--upgrade",
                 "pip",
                 "setuptools",
-                "pip-tools==6.12.1"
+                "pip-tools==6.13.0"
             )
         }
     }


### PR DESCRIPTION
## Info

FYI: New issue in Python projects with latest PIP version, so we need to upgrade pip-tools.

Could you please merge and release this version @dobe?

## PIP-Tools change log 6.13.0

Features:

- Add support for self-referential extras
([1791](https://github.com/jazzband/pip-tools/pull/1791)). Thanks q0w
- Add support for `pip==23.1` where removed `FormatControl` in `WheelCache`
([1834](https://github.com/jazzband/pip-tools/pull/1834)). Thanks atugushev
- Add support for `pip==23.1` where refactored requirement options
([1832](https://github.com/jazzband/pip-tools/pull/1832)). Thanks atugushev
- Add support for `pip==23.1` where deprecated `--install-option` has been removed
([1828](https://github.com/jazzband/pip-tools/pull/1828)). Thanks atugushev

Bug Fixes:

- Pass `--cache-dir` to `--pip-args` for backtracking resolver
([1827](https://github.com/jazzband/pip-tools/pull/1827)). Thanks q0w

Other Changes:

- Update examples in README ([1835](https://github.com/jazzband/pip-tools/pull/1835)).
Thanks lucaswerkmeister


## Python error example

```
WARNING: the legacy dependency resolver is deprecated and will be removed in future versions of pip-tools. The default resolver will be changed to 'backtracking' in pip-tools 7.0.0. Specify --resolver=backtracking to silence this warning.
Traceback (most recent call last):
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/bin/pip-compile", line 8, in <module>
    sys.exit(cli())
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/piptools/scripts/compile.py", line 580, in cli
    results = resolver.resolve(max_rounds=max_rounds)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/piptools/resolver.py", line 253, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/piptools/resolver.py", line 343, in _resolve_one_round
    their_constraints.extend(self._iter_dependencies(best_match))
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/piptools/resolver.py", line 456, in _iter_dependencies
    dependencies = self.repository.get_dependencies(ireq)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/piptools/repositories/local.py", line 87, in get_dependencies
    return self.repository.get_dependencies(ireq)
  File "/home/travis/build/lovelysystems/az.cmsui/tests/v/lib/python3.8/site-packages/piptools/repositories/pypi.py", line 237, in get_dependencies
    wheel_cache = WheelCache(self._cache_dir, self.options.format_control)
TypeError: __init__() takes 2 positional arguments but 3 were given
```