### PR TITLE
upgrade pip-tools to 7.5.3, pin setuptools < 81

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
 ## Develop
 
 - upgrade gradle to 8.14.3
+- upgrade pip-tools to 7.5.3 (fixes compatibility with pip >= 24.1)
+- pin setuptools < 81 (setuptools 81 removed pkg_resources)
 
 ## 2024-09-16 / 1.15.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes for Lovely Gradle Plugin
 
+## Develop
+
+- upgrade pip-tools to 7.5.3
+- pin setuptools < 81
+
 ## 2025-07-29 / 1.16.0
 
 ### Fix
@@ -15,8 +20,6 @@
 ## Develop
 
 - upgrade gradle to 8.14.3
-- upgrade pip-tools to 7.5.3 (fixes compatibility with pip >= 24.1)
-- pin setuptools < 81 (setuptools 81 removed pkg_resources)
 
 ## 2024-09-16 / 1.15.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Feature
 
 - upgrade pip-tools to 7.5.3
+- pin setuptools < 81
 
 ## 2025-07-29 / 1.16.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@
 ### Feature
 
 - upgrade pip-tools to 7.5.3
-- pin setuptools < 81
 
 ## 2025-07-29 / 1.16.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes for Lovely Gradle Plugin
 
-## Develop
+## Unreleased
+
+### Feature
 
 - upgrade pip-tools to 7.5.3
 - pin setuptools < 81

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -48,8 +48,7 @@ open class VenvTask : DefaultTask() {
             commandLine(
                 project.pythonSettings.pip, "install", "--upgrade",
                 "pip",
-                // setuptools 81 removed pkg_resources, still needed by gunicorn, sphinx, etc.
-                "setuptools<81",
+                "setuptools",
                 "pip-tools==7.5.3"
             )
         }

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -48,7 +48,8 @@ open class VenvTask : DefaultTask() {
             commandLine(
                 project.pythonSettings.pip, "install", "--upgrade",
                 "pip",
-                "setuptools",
+                // setuptools 81 removed pkg_resources, still needed by gunicorn, sphinx, etc.
+                "setuptools<81",
                 "pip-tools==7.5.3"
             )
         }

--- a/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
+++ b/src/main/kotlin/com/lovelysystems/gradle/PythonProject.kt
@@ -48,8 +48,9 @@ open class VenvTask : DefaultTask() {
             commandLine(
                 project.pythonSettings.pip, "install", "--upgrade",
                 "pip",
-                "setuptools",
-                "pip-tools==7.4.1"
+                // setuptools 81 removed pkg_resources, still needed by gunicorn, sphinx, etc.
+                "setuptools<81",
+                "pip-tools==7.5.3"
             )
         }
     }


### PR DESCRIPTION
Python venv bootstrap no longer breaks with pip >= 24.1 or setuptools >= 81.

## What

- Upgrade pip-tools from 7.4.1 to 7.5.3 — 7.4.1 crashes with pip >= 24.1 (`PackageFinder.allow_all_prereleases` removed)
- Pin setuptools < 81 — setuptools 81 removed `pkg_resources`, still needed by gunicorn, sphinx, etc.

## Risks

- Projects requiring Python < 3.9 will break (pip-tools 7.5.3 dropped 3.8 support)
- The setuptools < 81 pin is a stopgap; packages relying on `pkg_resources` should migrate to `importlib.metadata`

<details>
<summary>AI Attribution</summary>

- 3 of 5 commits co-authored with Claude
- Compatibility research, code change, changelog

</details>

---

#lovelyreviewdesc | base: c9026f0 | head: bc9f3e7